### PR TITLE
Put the Exception stacktrace in ProblemResponse::detail when in debug mode

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -10,10 +10,17 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 class ExceptionListener
 {
+    private $debugMode;
+
+    public function __construct($debugMode)
+    {
+        $this->debugMode = $debugMode;
+    }
+
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
-        $problem = new Exception($exception);
+        $problem = new Exception($exception, $debugMode);
 
         $event->setResponse(new ProblemResponse($problem));
     }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -19,9 +19,6 @@ class ExceptionListener
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        $exception = $event->getException();
-        $problem = new Exception($exception, $debugMode);
-
-        $event->setResponse(new ProblemResponse($problem));
+        $event->setResponse(new ProblemResponse(new Exception($event->getException(), $this->debugMode)));
     }
 }

--- a/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
@@ -7,11 +7,11 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 class Exception extends Problem
 {
 
-    public function __construct(\Exception $exception)
+    public function __construct(\Exception $exception, $includeStackTrace = false)
     {
         $this->problemType = "/exception";
         $this->title = $exception->getMessage();
-        $this->detail = $exception->getMessage();
+        $this->detail = $includeStackTrace ? $exception->getTraceAsString() : $exception->getMessage();
 
         switch(true) {
             case $exception instanceof HttpExceptionInterface;

--- a/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
+++ b/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
@@ -11,6 +11,6 @@ services:
 
   aw.rest_exception.listener:
     class: %aw.rest_exception.listener.class%
-    arguments: [@annotation_reader]
+    arguments: [%kernel.debug%]
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }


### PR DESCRIPTION
Debugging with behat can quite painful when we don't have the stacktraces of thrown exceptions.
