### PR TITLE
InvalidQueryForm's detail is now complete.

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/Problem/InvalidQueryForm.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Problem/InvalidQueryForm.php
@@ -16,9 +16,9 @@ class InvalidQueryForm extends Problem
     public function __construct(FormInterface $form)
     {
 
-        $this->title = "Invalid query";
+        $this->title = "Invalid query form";
         $this->detail = array(
-            'formErrors' => $this->buildErrorTree($form),
+            'errors' => $this->buildErrorsTree($form),
         );
         $this->httpStatus = 400;
     }
@@ -29,7 +29,7 @@ class InvalidQueryForm extends Problem
      *
      * @param FormInterface $form
      */
-    private function buildErrorTree($form) {
+    private function buildErrorsTree($form) {
         $errors = array();
 
         foreach ($form->getErrors() as $key => $error) {
@@ -37,7 +37,7 @@ class InvalidQueryForm extends Problem
         }
 
         foreach ($form->all() as $key => $child) {
-            if ($child instanceOf FormInterface && $err = $this->buildErrorTree($child)) {
+            if ($child instanceOf FormInterface && $err = $this->buildErrorsTree($child)) {
                 $errors[$key] = $err;
             }
         }

--- a/src/Alterway/Bundle/RestProblemBundle/Problem/InvalidQueryForm.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Problem/InvalidQueryForm.php
@@ -2,6 +2,8 @@
 
 namespace Alterway\Bundle\RestProblemBundle\Problem;
 
+use Symfony\Component\Form\FormInterface;
+
 /*
  * (c) 2013 La Ruche Qui Dit Oui!
  *
@@ -11,34 +13,35 @@ namespace Alterway\Bundle\RestProblemBundle\Problem;
 
 class InvalidQueryForm extends Problem
 {
-
-    public function __construct(\Symfony\Component\Form\FormInterface $form)
+    public function __construct(FormInterface $form)
     {
-        $formErrors = array();
-        $formChildrenErrors = array();
-
-        foreach ($form->getErrors() as $key => $error) {
-            $formErrors['generic'][$key] = $error->getMessage() . ' [parameters: ' . implode(', ', $error->getMessageParameters()) . ']';
-        }
-
-        foreach ($form->all() as $key => $child) {
-            if(!isset($errors[$key])) {
-                $formChildrenErrors[$key] = array();
-            }
-
-            $childErrors = $child->getErrors();
-            foreach($childErrors as  $err) {
-                $formChildrenErrors[$key][] = $err->getMessage();
-            }
-
-            if (empty($formChildrenErrors[$key])) {
-                unset($formChildrenErrors[$key]);
-            }
-        }
 
         $this->title = "Invalid query";
-        $this->detail = array_merge($formErrors, $formChildrenErrors);
+        $this->detail = array(
+            'formErrors' => $this->buildErrorTree($form),
+        );
         $this->httpStatus = 400;
     }
 
+    /**
+     * Recursively builds a tree of form errors (including children errors).
+     * Based on Form::getErrorsAsString() : https://github.com/symfony/Form/blob/master/Form.php#L750
+     *
+     * @param FormInterface $form
+     */
+    private function buildErrorTree($form) {
+        $errors = array();
+
+        foreach ($form->getErrors() as $key => $error) {
+            $errors[$key] = $error->getMessage();
+        }
+
+        foreach ($form->all() as $key => $child) {
+            if ($child instanceOf FormInterface && $err = $this->buildErrorTree($child)) {
+                $errors[$key] = $err;
+            }
+        }
+
+        return $errors;
+    }
 }

--- a/test/unit/Problem/InvalidQueryFormTest.php
+++ b/test/unit/Problem/InvalidQueryFormTest.php
@@ -14,21 +14,39 @@ class InvalidQueryFormTest extends PHPUnit_Framework_TestCase
         // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
         // $form = $this->getMock('\Symfony\Component\Form\FormInterface', array('all', 'getErrors'));
         $form = $this->getMock('\Symfony\Component\Form\Form', array('all', 'getErrors'), array(), '', false);
-        
+        $child = $this->getMock('\Symfony\Component\Form\Form', array('all', 'getErrors'), array(), '', false);
+        $error1 = new \Symfony\Component\Form\FormError("an error occured in the root form");
+        $error2 = new \Symfony\Component\Form\FormError("an error occured in a child form");
         
         $form
                 ->expects($this->once())
                 ->method('getErrors')
-                ->will($this->returnValue(array('field1' => array('an error occured'))))
+                ->will($this->returnValue(array($error1)))
         ;
         $form
+                ->expects($this->once())
+                ->method('all')
+                ->will($this->returnValue(array('child' => $child)))
+        ;
+
+        $child
+                ->expects($this->once())
+                ->method('getErrors')
+                ->will($this->returnValue(array($error2)))
+        ;
+        $child
                 ->expects($this->once())
                 ->method('all')
                 ->will($this->returnValue(array()))
         ;
 
         $object = new \Alterway\Bundle\RestProblemBundle\Problem\InvalidQueryForm($form);
-        $expected = array('field1' => array('an error occured'));
+        $expected = array(
+            'errors' => array(
+                'an error occured in the root form',
+                'child' => array('an error occured in a child form'),
+            ),
+        );
         $this->assertEquals($expected, $object->getDetail());
     }
     
@@ -54,7 +72,7 @@ class InvalidQueryFormTest extends PHPUnit_Framework_TestCase
         ;
 
         $object = new \Alterway\Bundle\RestProblemBundle\Problem\InvalidQueryForm($form);
-        $expected = array();
+        $expected = array('errors' => array());
         $this->assertEquals($expected, $object->getDetail());
     }
 


### PR DESCRIPTION
The detail of InvalidQueryForm is now constructed recursively, thus including all children errors instead of just the first level (ie fields).

Sample response : 

```
{
     "problemType": "http://not-specified-yet",
     "title": "Invalid query",
     "detail": {
         "formErrors": {
             "deliveryTimeSlot": {
                 "ending": [
                     "A timeslot should end after it has started."
                ]
            }
        }
    }
}
```
