### PR TITLE
Change the Exception's title from exception message to exception class.

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
@@ -10,7 +10,7 @@ class Exception extends Problem
     public function __construct(\Exception $exception, $includeStackTrace = false)
     {
         $this->problemType = "/exception";
-        $this->title = $exception->getMessage();
+        $this->title = get_class($exception);
         $this->detail = $includeStackTrace ? $exception->getTraceAsString() : $exception->getMessage();
 
         switch(true) {

--- a/test/unit/Problem/ExceptionTest.php
+++ b/test/unit/Problem/ExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @covers \Alterway\Bundle\RestProblemBundle\Problem\Exception
+ */
+class ExceptionTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testTitleIsExceptionClass()
+    {
+
+        $exception = new \LogicException();
+        $object = new \Alterway\Bundle\RestProblemBundle\Problem\Exception($exception);
+
+        $expected = 'LogicException';
+        $this->assertEquals($expected, $object->getTitle());
+    }
+}


### PR DESCRIPTION
This change can enable clients to rely on the Exception's class instead of
its message (which can be locale dependent). This enforces proper
Interface Segregation.
