### PR TITLE
Respect the status code provided by the problems definition.

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ProblemListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ProblemListener.php
@@ -43,7 +43,7 @@ class ProblemListener
         }
 
         $headers = array('Content-type' => 'application/api-problem+json');
-        $response = new ProblemResponse($resource, 400, $headers);
+        $response = new ProblemResponse($resource, $resource->getHttpStatus(), $headers);
         $event->setResponse($response);
     }
 


### PR DESCRIPTION
The status code that is provided by the problem definition should not be overridden by the bundle.
